### PR TITLE
GCIS-2786 docker-compose and Sumo setting update

### DIFF
--- a/custom-sumo-sources.json
+++ b/custom-sumo-sources.json
@@ -1,0 +1,16 @@
+{
+    "api.version": "v1",
+    "sources": [
+          {
+              "name": "Docker-logs",
+              "category": "docker",
+              "allContainers": true,
+              "collectEvents": true,
+              "uri": "unix:///var/run/docker.sock",
+              "specifiedContainers": [],
+              "multilineProcessingEnabled": false,
+              "sourceType": "DockerLog"
+          }
+     ]
+  }
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,10 +79,13 @@ services:
   #   container_name: gateway_sumologic
   #   volumes:
   #     - /var/run/docker.sock:/var/run/docker.sock
+  #     - ~/platform/custom-sumo-sources.json:/etc/custom-sumo-sources.json
   #   environment:
-  #     - SUMO_ACCESS_ID=[insert API key here]
+  #     - SUMO_ACCESS_ID=[insert API ID here]
   #     - SUMO_ACCESS_KEY=[insert API key here]
   #     - SUMO_COLLECTOR_NAME=[insert name here]
+  #     - SUMO_COLLECTOR_NAME_PREFIX=GCIS Data Gateway-
+  #     - SUMO_SOURCES_JSON=/etc/custom-sumo-sources.json
   # datadog:
   #   image: datadog/agent:7
   #   container_name: gateway_datadog


### PR DESCRIPTION
- Added "custom-sumo-sources.json" which is used for overriding the default collector source setting from sending both docker logs and docker stats to only sending docker logs to SumoLogic
- Modified "docker-compose.yml" file to include GCIS prefix for collector name and "custom-sumo-sources.json"